### PR TITLE
Fix split-string(nil) in gerrit-dashboard--cell-formatter

### DIFF
--- a/gerrit.el
+++ b/gerrit.el
@@ -935,9 +935,11 @@ alist."
                                            (first-name
                                             (car
                                              (split-string
-                                              (alist-get 'name (alist-get
-                                                                reviewer-account-id
-                                                                (gerrit-get-accounts-alist)))))))
+                                              (or
+                                               (alist-get 'name (alist-get
+                                                                 reviewer-account-id
+                                                                 (gerrit-get-accounts-alist)))
+                                               "N/A")))))
                                       (if part-of-attention-set
                                           (propertize (concat
                                                        gerrit-dashboard-attention-icon
@@ -954,8 +956,10 @@ alist."
                      (seq-map
                       (lambda (reviewer-info)
                         ;; return a real name of a reviewer in CC
-                        (alist-get 'name (alist-get reviewer-info
-                                                    (gerrit-get-accounts-alist))))
+                        (or
+                         (alist-get 'name (alist-get reviewer-info
+                                                     (gerrit-get-accounts-alist)))
+                         "N/A"))
                       (alist-get 'cc change-metadata))))
               (propertize (s-join " " reviewers) 'face 'magit-log-author)
             ""))


### PR DESCRIPTION
If `gerrit-dashboard` is called and a `reviewer-account-id` cannot be found from `(gerrit-get-accounts-alist)`,
`gerrit-dashboard--cell-formatter` calls `split-string` with a `nil` value. The following captured stack trace can be captured in this case (edited for readability):

```
  Debugger entered--Lisp error: (wrong-type-argument stringp nil)
    split-string(nil)
    ...
    gerrit-dashboard--cell-formatter(... "Reviewers")
    ...
    gerrit-dashboard--change-metadata-2-entry(...)
    ...
    gerrit-dashboard--get-data("has:draft")
    ...
    gerrit-dashboard--get-list-entries()
    gerrit-dashboard--refresh()
    gerrit-dashboard-mode()
    gerrit-dashboard()
    funcall-interactively(gerrit-dashboard)
    command-execute(gerrit-dashboard record)
    execute-extended-command(nil "gerrit-dashboard" "gerr")
    funcall-interactively(execute-extended-command nil "gerrit-dashboard" "gerr")
    command-execute(execute-extended-command)
```

The above was triggered for the "Reviewers" column in `gerrit-dashboard--cell-formatter`. This could for instance happen if a user is removed from the Gerrit instance's database but the `change-metadata` still list them (at least that's what I think has happened on my instance).

Fix this by instead returning "N/A" as name if `reviewer-account-id` can't be found in `(gerrit-get-accounts-alist)`. There is only one other place where `(gerrit-get-accounts-alist)` is called and checked in a similar way, the "CC" column. While this column hasn't triggered this error, it doesn't hurt to be defensive and fix it here also.